### PR TITLE
Added in a suffix map

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var toCamelCase = require('to-camel-case');
 
+var s = setup();
+
 module.exports = style;
+module.exports.setup = setup;
 module.exports.hide = effect('display', 'none');
 module.exports.show = effect('display', 'initial');
 
@@ -18,7 +21,18 @@ function effect(name, value) {
 }
 
 function one(element, name, value) {
+  if( typeof value == 'number' )
+    value += s.numberAppend;
+
   element.style[toCamelCase((name == 'float') ? 'cssFloat' : name)] = value;
+}
+
+function setup(settings) {
+  var s = settings || {};
+
+  s.numberAppend = s.numberAppend || 'px';
+
+  return s;
 }
 
 function style(element) {

--- a/index.js
+++ b/index.js
@@ -21,16 +21,21 @@ function effect(name, value) {
 }
 
 function one(element, name, value) {
-  if( typeof value == 'number' )
-    value += s.numberAppend;
 
-  element.style[toCamelCase((name == 'float') ? 'cssFloat' : name)] = value;
+  var propName = toCamelCase((name == 'float') ? 'cssFloat' : name);
+
+  if (s.suffix[propName] && typeof value == 'number')
+    value += s.suffix[propName];
+
+  element.style[propName] = value;
 }
 
 function setup(settings) {
-  var s = settings || {};
+  var s = settings || {},
+      p = 'px';
 
-  s.numberAppend = s.numberAppend || 'px';
+  //the following suffix map is what TweenLite uses: https://github.com/greensock/GreenSock-JS
+  s.suffix = s.suffix || {top:p, right:p, bottom:p, left:p, width:p, height:p, fontSize:p, padding:p, margin:p, perspective:p, lineHeight:""};;
 
   return s;
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var toCamelCase = require('to-camel-case');
 
+var s = setup();
+
 module.exports = style;
+module.exports.setup = setup;
 module.exports.hide = effect('display', 'none');
 module.exports.show = effect('display', 'initial');
 
@@ -18,7 +21,19 @@ function effect(name, value) {
 }
 
 function one(element, name, value) {
+
+  if( typeof value == 'number' )
+    value += s.numberAppend;
+
   element.style[toCamelCase((name == 'float') ? 'cssFloat' : name)] = value;
+}
+
+function setup(settings) {
+  var s = settings || {};
+
+  s.numberAppend = s.numberAppend || 'px';
+
+  return s;
 }
 
 function style(element) {


### PR DESCRIPTION
If a value for css is a number a suffix will be added to the value based on a suffix map.

For instance. 

Currently you'd have to write:

```
var w = 100;

{
    width: w + 'px'
}
```

Now you'd have to just do:

```
var w = 100;

{
    width: w
}
```
